### PR TITLE
Deprecate in favor of MapPointMapper-Swift?

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # Map Point Mapper
 
+## Deprecation Notice!
 
+This repository is now inactive and has been deprecated in favor of the [MapPointMapper-Swift
+repo](https://github.com/househappy/MapPointMapper-Swift) to simplify
+development, testing, and maintenance.  Please use that one and open any
+issues/PRs there.


### PR DESCRIPTION
i dont think we're actually going to keep this maintained... at this point it's pretty behind.  maybe we should close the repo, but ehh still nice to have around
